### PR TITLE
custom addr and fix reset timing issue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,16 @@
 
 extern crate embedded_hal as ehal;
 
+/// The I2C address of a [`BMP388`] sensor.
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum Addr {
+    /// The primary I2C address.
+    Primary = 0x76,
+    /// The secondary I2C address.
+    Secondary = 0x77,
+}
+
 /// BMP388 driver
 pub struct BMP388<I2C: ehal::blocking::i2c::WriteRead> {
     com: I2C,
@@ -138,7 +148,6 @@ impl<I2C: ehal::blocking::i2c::WriteRead> BMP388<I2C> {
         let compensated_press = partial_out1 + partial_out2 + partial_data4;
 
         compensated_press
-        
     }
 
     /// Compensates a temperature value
@@ -309,7 +318,7 @@ impl<I2C: ehal::blocking::i2c::WriteRead> BMP388<I2C> {
             temperature_data_ready: status & (1 << 6) != 0,
         })
     }
-    
+
     ///Get the error register
     pub fn error(&mut self) -> Result<Error, I2C::Error> {
         let error = self.read_byte(Register::err)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub struct BMP388<I2C: ehal::blocking::i2c::WriteRead> {
 
 impl<I2C: ehal::blocking::i2c::WriteRead> BMP388<I2C> {
     /// Creates new BMP388 driver
-    pub fn new<E>(i2c: I2C, addr: u8) -> Result<BMP388<I2C>, E>
+    pub fn new<E>(i2c: I2C, addr: u8, delay: &mut impl ehal::blocking::delay::DelayMs<u8>) -> Result<BMP388<I2C>, E>
     where
         I2C: ehal::blocking::i2c::WriteRead<Error = E>,
     {
@@ -57,6 +57,7 @@ impl<I2C: ehal::blocking::i2c::WriteRead> BMP388<I2C> {
 
         if chip.id()? == 0x50 {
             chip.reset()?;
+            delay.delay_ms(10); // without this the first few bytes of calib data could be incorrectly zero
             chip.read_calibration()?;
         }
 


### PR DESCRIPTION
This adds a param that can be used to set a custom i2c address.

Also fixes a timing issue where the reset right before reading calibration data can result in the first few bytes of calibration data being zero (which permanently throws off all readings since there's no public api to re-read the calibration data).