### PR TITLE
feat: Add BMP390 chip id and update the chip id check

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -21,7 +21,8 @@ impl<I2C: embedded_hal_async::i2c::I2c> BMP388<I2C, Async> {
             phantom: PhantomData,
         };
 
-        if chip.id().await? == CHIP_ID {
+        let chip_id = chip.id().await?;
+        if [CHIP_ID, BMP390_CHIP_ID].contains(&chip_id) {
             chip.reset().await?;
             // without this the first few bytes of calib data could be incorrectly zero
             delay.delay_ms(10).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,10 @@ mod asynch;
 
 pub mod config;
 
-/// The expected value of the ChipId register
+/// The expected value of the ChipId register for BMP388
 pub const CHIP_ID: u8 = 0x50;
+/// The expected value of the ChipId register for BMP390
+pub const BMP390_CHIP_ID: u8 = 0x60;
 
 /// The I2C address of a [`BMP388`] sensor.
 ///
@@ -242,7 +244,8 @@ impl<I2C: ehal::i2c::I2c> BMP388<I2C, Blocking> {
             phantom: PhantomData,
         };
 
-        if chip.id()? == CHIP_ID {
+        let chip_id = chip.id()?;
+        if [CHIP_ID, BMP390_CHIP_ID].contains(&chip_id) {
             chip.reset()?;
             // without this the first few bytes of calib data could be incorrectly zero
             delay.delay_ms(10);


### PR DESCRIPTION
Still needs testing as we are testing our bmp390 board and I don't have other boards with this sensor.
The only differences is the chip ID as far as I found in this library:

https://github.com/adafruit/Adafruit_CircuitPython_BMP3XX/blob/main/adafruit_bmp3xx.py